### PR TITLE
Improve mem check value lookup

### DIFF
--- a/check_rabbitmq
+++ b/check_rabbitmq
@@ -96,9 +96,17 @@ def check_mem_usage(critical=75, warning=50):
     """Check to make sure the RAM usage of rabbitmq process does not exceed 50%% of its max"""
     try:
         results = RabbitCmdWrapper.status()
-        memory_used  = float(filter(str.isdigit, results[20][0]))
-        memory_limit = float(filter(str.isdigit, results[40][0]))
+
+        for idx,val in enumerate(results):
+          if "memory," in str(val):
+              mem_used_raw = str(results[idx + 1])
+          if "vm_memory_limit" in str(val):
+              mem_limit_raw = str(val)
+
+        memory_used = float(filter(str.isdigit, mem_used_raw))
+        memory_limit = float(filter(str.isdigit, mem_limit_raw))
         percent_usage = int(memory_used/memory_limit * 100)
+
         if percent_usage > critical:
             print "CRITICAL - RABBITMQ RAM USAGE at %s%% of max" % percent_usage
             sys.exit(2)


### PR DESCRIPTION
The current check_mem_usage looks at static values in the `results` list. That does not account for a change in the size of the list (esp the running applications). This makes the lookup a little more intelligent. Eventually I would like to parse the erlang proplist into JSON but this is a good workaround for now 

RFC @CaptPhunkosis 

The proplist from `sudo rabbitmqctl status` as `idx/val` pairs:

```
(0, ['[{pid,30038},'])
(1, [' {running_applications,'])
(2, ['     [{rabbitmq_management,"RabbitMQ Management Console","3.5.3"},'])
(3, ['      {rabbitmq_web_dispatch,"RabbitMQ Web Dispatcher","3.5.3"},'])
(4, ['      {webmachine,"webmachine","1.10.3-rmq3.5.3-gite9359c7"},'])
(5, ['      {rabbitmq_management_agent,"RabbitMQ Management Agent","3.5.3"},'])
(6, ['      {rabbit,"RabbitMQ","3.5.3"},'])
(7, ['      {amqp_client,"RabbitMQ AMQP Client","3.5.3"},'])
(8, ['      {mochiweb,"MochiMedia Web Server","2.7.0-rmq3.5.3-git680dba8"},'])
(9, ['      {xmerl,"XML parser","1.3.8"},'])
(10, ['      {inets,"INETS  CXC 138 49","6.0"},'])
(11, ['      {os_mon,"CPO  CXC 138 46","2.4"},'])
(12, ['      {mnesia,"MNESIA  CXC 138 12","4.13"},'])
(13, ['      {sasl,"SASL  CXC 138 11","2.5"},'])
(14, ['      {stdlib,"ERTS  CXC 138 10","2.5"},'])
(15, ['      {kernel,"ERTS  CXC 138 10","4.0"}]},'])
(16, [' {os,{unix,linux}},'])
(17, [' {erlang_version,'])
(18, ['     "Erlang/OTP 18 [erts-7.0] [source] [64-bit] [smp:2:2] [async-threads:30] [hipe] [kernel-poll:true]\\n"},'])
(19, [' {memory,'])
(20, ['     [{total,75405024},'])
(21, ['      {connection_readers,1036384},'])
(22, ['      {connection_writers,1649584},'])
(23, ['      {connection_channels,4503816},'])
(24, ['      {connection_other,2985640},'])
(25, ['      {queue_procs,2314600},'])
(26, ['      {queue_slave_procs,0},'])
(27, ['      {plugins,3191368},'])
(28, ['      {other_proc,10990992},'])
(29, ['      {mnesia,1125136},'])
(30, ['      {mgmt_db,13102072},'])
(31, ['      {msg_index,100776},'])
(32, ['      {other_ets,1485664},'])
(33, ['      {binary,2872312},'])
(34, ['      {code,20085336},'])
(35, ['      {atom,1919209},'])
(36, ['      {other_system,8042135}]},'])
(37, [' {alarms,[]},'])
(38, [' {listeners,[{clustering,25672,"::"},{amqp,5672,"::"}]},'])
(39, [' {vm_memory_high_watermark,0.4},'])
(40, [' {vm_memory_limit,1257979904},'])
(41, [' {disk_free_limit,50000000},'])
(42, [' {disk_free,21159264256},'])
(43, [' {file_descriptors,'])
(44, ['     [{total_limit,16284},'])
(45, ['      {total_used,23},'])
(46, ['      {sockets_limit,14653},'])
(47, ['      {sockets_used,21}]},'])
(48, [' {processes,[{limit,1048576},{used,1593}]},'])
(49, [' {run_queue,0},'])
```