### PR TITLE
Specify Python version

### DIFF
--- a/check_rabbitmq
+++ b/check_rabbitmq
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from optparse import OptionParser
 import shlex
 import subprocess


### PR DESCRIPTION
As Python 2 syntax is used shebang should reflect that so it doesn't break on systems with python 3 as default version.