### PR TITLE
Add perfdata in connections, handle with or w/o thresholds

### DIFF
--- a/check_rabbitmq
+++ b/check_rabbitmq
@@ -7,6 +7,8 @@ import requests
 import json
 import re
 
+version = "20200827"
+
 if "check_output" not in dir( subprocess ): # duck punch it in!
   def f(*popenargs, **kwargs):
       if 'stdout' in kwargs:
@@ -61,19 +63,29 @@ class RabbitCmdWrapper(object):
             return_data.append(row.split('\t'))
         return return_data
 
+def threshold_sanity(critical, warning):
+    """Make sure we use both thresholds, not just one"""
+    if warning and not critical:
+        print "UNKNOWN - Define both thresholds, not just warning"
+        sys.exit(3)
+    elif critical and not warning:
+        print "UNKNOWN - Define both thresholds, not just critical"
 
 def check_connection_count(critical=0, warning=0):
     """Checks to make sure the numbers of connections are within parameters."""
     try:
         count = len(RabbitCmdWrapper.list_connections())
-        if count >= critical:
-            print "CRITICAL - Connection Count %d" % count
-            sys.exit(2)
-        elif count >= warning:
-            print "WARNING - Connection Count %d" % count
-            sys.exit(1)
+        if (critical and warning):
+          if count >= critical:
+              print "CRITICAL - Connection Count {0}|connections={0};{1};{2};0;;" .format(count,warning,critical)
+              sys.exit(2)
+          elif count >= warning:
+              print "WARNING - Connection Count {0}|connections={0};{1};{2};0;;" .format(count,warning,critical)
+              sys.exit(1)
+          else:
+              print "OK - Connection Count {0}|connections={0};{1};{2};0;;" .format(count,warning,critical)
         else:
-            print "OK - Connection Count %d" % count
+          print "OK - Connection Count {0}|connections={0};;;0;;" .format(count)
     except Exception, err:
         print "CRITICAL - %s" % err
 
@@ -181,7 +193,8 @@ def check_cluster(username, password, timeout, cluster):
        sys.exit(0)
 
 
-USAGE = """Usage: ./check_rabbitmq -a [action] -C [critical] -W [warning]
+USAGE = """check_rabbitmq v {0} copyright 2011-2020 CaptPhunkosis and contributors
+           Usage: ./check_rabbitmq -a action [-C critical] [-W warning]
            Actions:
            - connection_count
              checks the number of connection in rabbitmq's list_connections
@@ -192,7 +205,7 @@ USAGE = """Usage: ./check_rabbitmq -a [action] -C [critical] -W [warning]
            - aliveness
              Use the /api/aliveness-test API to send/receive a message. (requires -u username -p password args)
            - cluster_status
-             Parse /api/nodes to check the cluster status. (requires -u username -p password"""
+             Parse /api/nodes to check the cluster status. (requires -u username -p password""" .format(version)
 
 if __name__ == "__main__":
     parser = OptionParser(USAGE)
@@ -213,6 +226,7 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args()
 
     if options.action == "connection_count":
+        threshold_sanity(options.critical, options.warning)
         check_connection_count(options.critical, options.warning)
     elif options.action == "queues_count":
         check_queues_count(options.critical, options.warning)


### PR DESCRIPTION
First of all: Thanks for maintaining this plugin!

Couple of changes in this PR, nothing huge.

- Add a version so plugins in the wild can easily be compared to see which version is currently locally used. I chose date here because I don't know with all the patches in the past what version that would actually be. Feel free to adapt :)
- Add function threshold sanity to check for both thresholds (warn and crit) are defined
- Adapt connection_count check to handle the output with and without thresholds and add performance data to the output